### PR TITLE
Add rimraf module to fix npm clean script failed issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.1.0-beta"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "rimraf": "^2.6.1"
+  },
   "keywords": [],
   "main": "src/index.js",
   "private": true,


### PR DESCRIPTION
npm run clean 會出錯，發現是少了rimraf，補上此套件就正常了。